### PR TITLE
Closes #68 Fix: Address race condition in CUDA allocator during k-mer counting

### DIFF
--- a/__bin3/CombSorterTests.cs
+++ b/__bin3/CombSorterTests.cs
@@ -1,0 +1,43 @@
+using Algorithms.Sorters.Comparison;
+using Algorithms.Tests.Helpers;
+
+namespace Algorithms.Tests.Sorters.Comparison;
+
+public static class CombSorterTests
+{
+    [Test]
+    public static void ArraySorted(
+        [Random(0, 1000, 100, Distinct = true)]
+        int n)
+    {
+        // Arrange
+        var sorter = new CombSorter<int>();
+        var intComparer = new IntComparer();
+        var (correctArray, testArray) = RandomHelper.GetArrays(n);
+
+        // Act
+        sorter.Sort(testArray, intComparer);
+        Array.Sort(correctArray, intComparer);
+
+        // Assert
+        Assert.That(correctArray, Is.EqualTo(testArray));
+    }
+
+    [Test]
+    public static void ArraySorted_WithCustomShrinkFactor(
+        [Random(0, 1000, 100, Distinct = true)]
+        int n)
+    {
+        // Arrange
+        var sorter = new CombSorter<int>(1.5);
+        var intComparer = new IntComparer();
+        var (correctArray, testArray) = RandomHelper.GetArrays(n);
+
+        // Act
+        sorter.Sort(testArray, intComparer);
+        Array.Sort(correctArray, intComparer);
+
+        // Assert
+        Assert.That(correctArray, Is.EqualTo(testArray));
+    }
+}

--- a/__bin3/QueueByTwoStacks.java
+++ b/__bin3/QueueByTwoStacks.java
@@ -1,0 +1,88 @@
+package com.thealgorithms.datastructures.queues;
+
+import java.util.NoSuchElementException;
+import java.util.Stack;
+
+/**
+ * A queue implementation using two stacks. This class provides methods to
+ * enqueue (add) elements to the end of the queue and dequeue (remove)
+ * elements from the front, while utilizing two internal stacks to manage
+ * the order of elements.
+ *
+ * @param <T> The type of elements held in this queue.
+ */
+@SuppressWarnings("unchecked")
+public class QueueByTwoStacks<T> {
+
+    private final Stack<T> enqueueStk;
+    private final Stack<T> dequeueStk;
+
+    /**
+     * Constructor that initializes two empty stacks for the queue.
+     * The `enqueueStk` is used to push elements when enqueuing, and
+     * the `dequeueStk` is used to pop elements when dequeuing.
+     */
+    public QueueByTwoStacks() {
+        enqueueStk = new Stack<>();
+        dequeueStk = new Stack<>();
+    }
+
+    /**
+     * Adds an element to the end of the queue. This method pushes the element
+     * onto the `enqueueStk`.
+     *
+     * @param item The element to be added to the queue.
+     */
+    public void put(T item) {
+        enqueueStk.push(item);
+    }
+
+    /**
+     * Removes and returns the element at the front of the queue.
+     * If `dequeueStk` is empty, it transfers all elements from
+     * `enqueueStk` to `dequeueStk` to maintain the correct FIFO
+     * (First-In-First-Out) order before popping.
+     *
+     * @return The element at the front of the queue.
+     * @throws NoSuchElementException If the queue is empty.
+     */
+    public T get() {
+        if (dequeueStk.isEmpty()) {
+            while (!enqueueStk.isEmpty()) {
+                dequeueStk.push(enqueueStk.pop());
+            }
+        }
+        if (dequeueStk.isEmpty()) {
+            throw new NoSuchElementException("Queue is empty");
+        }
+        return dequeueStk.pop();
+    }
+
+    /**
+     * Returns the total number of elements currently in the queue.
+     * This is the sum of the sizes of both stacks.
+     *
+     * @return The number of elements in the queue.
+     */
+    public int size() {
+        return enqueueStk.size() + dequeueStk.size();
+    }
+
+    /**
+     * Returns a string representation of the queue, showing the elements
+     * in the correct order (from front to back).
+     * The `dequeueStk` is first cloned, and then all elements from the
+     * `enqueueStk` are added to the cloned stack in reverse order to
+     * represent the queue accurately.
+     *
+     * @return A string representation of the queue.
+     */
+    @Override
+    public String toString() {
+        Stack<T> tempStack = (Stack<T>) dequeueStk.clone();
+        while (!enqueueStk.isEmpty()) {
+            tempStack.push(enqueueStk.pop());
+        }
+        return "Queue(" + tempStack + ")";
+    }
+}

--- a/__bin3/WusLineTest.java
+++ b/__bin3/WusLineTest.java
@@ -1,0 +1,90 @@
+package com.thealgorithms.geometry;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for the {@link WusLine} class.
+ */
+class WusLineTest {
+
+    @Test
+    void testSimpleLineProducesPixels() {
+        List<WusLine.Pixel> pixels = WusLine.drawLine(2, 2, 6, 4);
+        assertFalse(pixels.isEmpty(), "Line should produce non-empty pixel list");
+    }
+
+    @Test
+    void testEndpointsIncluded() {
+        List<WusLine.Pixel> pixels = WusLine.drawLine(0, 0, 5, 3);
+        boolean hasStart = pixels.stream().anyMatch(p -> p.point.equals(new java.awt.Point(0, 0)));
+        boolean hasEnd = pixels.stream().anyMatch(p -> p.point.equals(new java.awt.Point(5, 3)));
+        assertTrue(hasStart, "Start point should be represented in the pixel list");
+        assertTrue(hasEnd, "End point should be represented in the pixel list");
+    }
+
+    @Test
+    void testIntensityInRange() {
+        List<WusLine.Pixel> pixels = WusLine.drawLine(1, 1, 8, 5);
+        for (WusLine.Pixel pixel : pixels) {
+            assertTrue(pixel.intensity >= 0.0 && pixel.intensity <= 1.0, "Intensity must be clamped between 0.0 and 1.0");
+        }
+    }
+
+    @Test
+    void testReversedEndpointsProducesSameLine() {
+        List<WusLine.Pixel> forward = WusLine.drawLine(2, 2, 10, 5);
+        List<WusLine.Pixel> backward = WusLine.drawLine(10, 5, 2, 2);
+
+        // They should cover same coordinates (ignoring order)
+        var forwardPoints = forward.stream().map(p -> p.point).collect(java.util.stream.Collectors.toSet());
+        var backwardPoints = backward.stream().map(p -> p.point).collect(java.util.stream.Collectors.toSet());
+
+        assertEquals(forwardPoints, backwardPoints, "Reversing endpoints should yield same line pixels");
+    }
+
+    @Test
+    void testSteepLineHasProperCoverage() {
+        // Steep line: Δy > Δx
+        List<WusLine.Pixel> pixels = WusLine.drawLine(3, 2, 5, 10);
+        assertFalse(pixels.isEmpty());
+        // Expect increasing y values
+        long increasing = 0;
+        for (int i = 1; i < pixels.size(); i++) {
+            if (pixels.get(i).point.y >= pixels.get(i - 1).point.y) {
+                increasing++;
+            }
+        }
+        assertTrue(increasing > pixels.size() / 2, "Steep line should have increasing y coordinates");
+    }
+
+    @Test
+    void testZeroLengthLineUsesDefaultGradient() {
+        // same start and end -> dx == 0 -> gradient should take the (dx == 0) ? 1.0 branch
+        List<WusLine.Pixel> pixels = WusLine.drawLine(3, 3, 3, 3);
+
+        // sanity checks: we produced pixels and the exact point is present
+        assertFalse(pixels.isEmpty(), "Zero-length line should produce at least one pixel");
+        assertTrue(pixels.stream().anyMatch(p -> p.point.equals(new java.awt.Point(3, 3))), "Pixel list should include the single-point coordinate (3,3)");
+    }
+
+    @Test
+    void testHorizontalLineIntensityStable() {
+        List<WusLine.Pixel> pixels = WusLine.drawLine(1, 5, 8, 5);
+
+        // For each x, take the max intensity among pixels with that x (the visible intensity for the column)
+        java.util.Map<Integer, Double> maxIntensityByX = pixels.stream()
+                                                             .collect(java.util.stream.Collectors.groupingBy(p -> p.point.x, java.util.stream.Collectors.mapping(p -> p.intensity, java.util.stream.Collectors.maxBy(Double::compareTo))))
+                                                             .entrySet()
+                                                             .stream()
+                                                             .collect(java.util.stream.Collectors.toMap(java.util.Map.Entry::getKey, e -> e.getValue().orElse(0.0)));
+
+        double avgMaxIntensity = maxIntensityByX.values().stream().mapToDouble(Double::doubleValue).average().orElse(0.0);
+
+        assertTrue(avgMaxIntensity > 0.5, "Average of the maximum per-x intensities should be > 0.5 for a horizontal line");
+    }
+}

--- a/__bin3/bitonic_sort.rs
+++ b/__bin3/bitonic_sort.rs
@@ -1,0 +1,52 @@
+fn _comp_and_swap<T: Ord>(array: &mut [T], left: usize, right: usize, ascending: bool) {
+    if (ascending && array[left] > array[right]) || (!ascending && array[left] < array[right]) {
+        array.swap(left, right);
+    }
+}
+
+fn _bitonic_merge<T: Ord>(array: &mut [T], low: usize, length: usize, ascending: bool) {
+    if length > 1 {
+        let middle = length / 2;
+        for i in low..(low + middle) {
+            _comp_and_swap(array, i, i + middle, ascending);
+        }
+        _bitonic_merge(array, low, middle, ascending);
+        _bitonic_merge(array, low + middle, middle, ascending);
+    }
+}
+
+pub fn bitonic_sort<T: Ord>(array: &mut [T], low: usize, length: usize, ascending: bool) {
+    if length > 1 {
+        let middle = length / 2;
+        bitonic_sort(array, low, middle, true);
+        bitonic_sort(array, low + middle, middle, false);
+        _bitonic_merge(array, low, length, ascending);
+    }
+}
+
+//Note that this program works only when size of input is a power of 2.
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sorting::have_same_elements;
+    use crate::sorting::is_descending_sorted;
+    use crate::sorting::is_sorted;
+
+    #[test]
+    fn descending() {
+        //descending
+        let mut ve1 = vec![6, 5, 4, 3];
+        let cloned = ve1.clone();
+        bitonic_sort(&mut ve1, 0, 4, true);
+        assert!(is_sorted(&ve1) && have_same_elements(&ve1, &cloned));
+    }
+
+    #[test]
+    fn ascending() {
+        //pre-sorted
+        let mut ve2 = vec![1, 2, 3, 4];
+        let cloned = ve2.clone();
+        bitonic_sort(&mut ve2, 0, 4, false);
+        assert!(is_descending_sorted(&ve2) && have_same_elements(&ve2, &cloned));
+    }
+}

--- a/__bin3/inttoroman_test.go
+++ b/__bin3/inttoroman_test.go
@@ -1,0 +1,30 @@
+package conversion
+
+import "testing"
+
+func TestIntToRoman(t *testing.T) {
+	for expected, input := range romanTestCases {
+		out, err := IntToRoman(input)
+		if err != nil {
+			t.Errorf("IntToRoman(%d) returned an error %s", input, err.Error())
+		}
+		if out != expected {
+			t.Errorf("IntToRoman(%d) = %s; want %s", input, out, expected)
+		}
+	}
+	_, err := IntToRoman(100000)
+	if err == nil {
+		t.Errorf("IntToRoman(%d) expected an error", 100000)
+	}
+	_, err = IntToRoman(0)
+	if err == nil {
+		t.Errorf("IntToRoman(%d) expected an error", 0)
+	}
+}
+
+func BenchmarkIntToRoman(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_, _ = IntToRoman(3999)
+	}
+}

--- a/__bin3/isisogram_test.go
+++ b/__bin3/isisogram_test.go
@@ -1,0 +1,131 @@
+package strings_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/TheAlgorithms/Go/strings"
+)
+
+var testCases = []struct {
+	name        string
+	input       string
+	order       strings.IsogramOrder
+	expectedVal bool
+	expectedErr error
+}{
+	{
+		"Alphanumeric string 1",
+		"copy1",
+		1,
+		false,
+		errors.New("Cannot contain numbers or symbols"),
+	},
+	{
+		"Alphanumeric string 2",
+		"copy1sentence",
+		1,
+		false,
+		errors.New("Cannot contain numbers or symbols"),
+	},
+	{
+		"Alphanumeric string 3",
+		"copy1 sentence with space",
+		1,
+		false,
+		errors.New("Cannot contain numbers or symbols"),
+	},
+	{
+		"Alphabetic string 1",
+		"allowance",
+		1,
+		false,
+		nil,
+	},
+	{
+		"Alphabetic string 2",
+		"My Doodle",
+		1,
+		false,
+		nil,
+	},
+	{
+		"Alphabetic string with symbol",
+		"Isogram!",
+		1,
+		false,
+		errors.New("Cannot contain numbers or symbols"),
+	},
+	{
+		"Isogram string 1",
+		"Uncopyrightable",
+		1,
+		true,
+		nil,
+	},
+	{
+		"Second order isogram 1",
+		"Caucasus",
+		2,
+		true,
+		nil,
+	},
+	{
+		"Second order isogram 2",
+		"Couscous",
+		2,
+		true,
+		nil,
+	},
+	{
+		"Third order isogram 1",
+		"Deeded",
+		3,
+		true,
+		nil,
+	},
+	{
+		"Third order isogram 2",
+		"Sestettes",
+		3,
+		true,
+		nil,
+	},
+	{
+		"Not an isogram",
+		"Pneumonoultramicroscopicsilicovolcanoconiosis",
+		1,
+		false,
+		nil,
+	},
+	{
+		"Not an isogram",
+		"Randomstring",
+		4,
+		false,
+		errors.New("Invalid isogram order provided"),
+	},
+	{
+		"Third order isogram checked as first order",
+		"Deeded",
+		1,
+		false,
+		nil,
+	},
+}
+
+func TestIsIsogram(t *testing.T) {
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			actualVal, actualErr := strings.IsIsogram(test.input, test.order)
+
+			if actualErr != nil && test.expectedErr.Error() != actualErr.Error() {
+				t.Errorf("Expected to be '%v' for string %s but was '%v'.", test.expectedErr, test.input, actualErr)
+			}
+
+			if test.expectedVal != actualVal {
+				t.Errorf("Expected to be '%v' for string %s but was '%v'.", test.expectedVal, test.input, actualVal)
+			}
+		})
+	}
+}

--- a/__bin3/lasso.md
+++ b/__bin3/lasso.md
@@ -1,0 +1,82 @@
+
+
+``` r
+data(ggplot2::diamonds)
+```
+
+```
+## Warning in data(ggplot2::diamonds): data set 'ggplot2::diamonds' not found
+```
+
+``` r
+library(caret)
+```
+
+```
+## Error in library(caret): there is no package called 'caret'
+```
+
+``` r
+library(dplyr)
+```
+
+```
+## Error in library(dplyr): there is no package called 'dplyr'
+```
+
+``` r
+dia.trans<-bind_cols(diamonds %>% select_if(is.numeric),
+                     model.matrix(~cut-1,diamonds) %>% as_tibble(),
+                     model.matrix(~color-1,diamonds) %>% as_tibble(),
+                     model.matrix(~clarity-1,diamonds) %>% as_tibble())
+```
+
+```
+## Error in bind_cols(diamonds %>% select_if(is.numeric), model.matrix(~cut - : could not find function "bind_cols"
+```
+
+``` r
+#setting parameters alpha and lambda
+lasso_expand<-expand.grid(alpha = 1, lambda = seq(0.001,0.1,by = 0.0005))
+lasso_mod <- train(x=dia.trans %>% select(-price), y=dia.trans$price, method='glmnet', 
+                   tuneGrid=lasso_expand)
+```
+
+```
+## Error in train(x = dia.trans %>% select(-price), y = dia.trans$price, : could not find function "train"
+```
+
+``` r
+#best tune
+lasso_mod$bestTune
+```
+
+```
+## Error: object 'lasso_mod' not found
+```
+
+``` r
+lasso_mod$results$RMSE
+```
+
+```
+## Error: object 'lasso_mod' not found
+```
+
+``` r
+lasso_imp<-varImp(lasso_mod)
+```
+
+```
+## Error in varImp(lasso_mod): could not find function "varImp"
+```
+
+``` r
+#get the importance of each feature and eliminate some of them
+lasso_imp$importance
+```
+
+```
+## Error: object 'lasso_imp' not found
+```
+


### PR DESCRIPTION
68 Rejected the feature request for Excel-to-VCF conversion as it is outside the current scope of this project. Our focus remains on high-throughput cloud-native formats like Zarr and Parquet. Users are encouraged to use external conversion utilities before ingesting data into the pipeline.